### PR TITLE
Implement a polyfill for `path_readlink`.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
 [build]
 target = 'wasm32-wasi'
+
+[target.wasm32-wasi]
 rustflags = ['-Clink-arg=--import-memory']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,5 @@ jobs:
     - run: rustup target add wasm32-wasi
     - run: cargo build
     - run: cargo run -p verify --target x86_64-unknown-linux-gnu ./target/wasm32-wasi/debug/wasi_snapshot_preview1.wasm
-      env:
-        RUSTFLAGS:
     - run: cargo build --release
     - run: cargo run -p verify --target x86_64-unknown-linux-gnu ./target/wasm32-wasi/release/wasi_snapshot_preview1.wasm
-      env:
-        RUSTFLAGS:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Covenant Code of Conduct
+
+*Note*: this Code of Conduct pertains to individuals' behavior. Please also see the [Organizational Code of Conduct][OCoC].
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Bytecode Alliance CoC team at [report@bytecodealliance.org](mailto:report@bytecodealliance.org). The CoC team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The CoC team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the Bytecode Alliance's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[OCoC]: https://github.com/sunfishcode/preview1.wasm/blob/main/ORG_CODE_OF_CONDUCT.md
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/1/4/

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,29 @@
+Short version for non-lawyers:
+
+`wasi_snapshot_preview1.wasm` is triple-licensed under Apache 2.0 with the LLVM Exception,
+Apache 2.0, and MIT terms.
+
+
+Longer version:
+
+Copyrights in the `wasi_snapshot_preview1.wasm` project are retained by their contributors.
+No copyright assignment is required to contribute to the `wasi_snapshot_preview1.wasm`
+project.
+
+Some files include code derived from Rust's `libstd`; see the comments in
+the code for details.
+
+Except as otherwise noted (below and/or in individual files), `wasi_snapshot_preview1.wasm`
+is licensed under:
+
+ - the Apache License, Version 2.0, with the LLVM Exception
+   <LICENSE-Apache-2.0_WITH_LLVM-exception> or
+   <http://llvm.org/foundation/relicensing/LICENSE.txt>
+ - the Apache License, Version 2.0
+   <LICENSE-APACHE> or
+   <http://www.apache.org/licenses/LICENSE-2.0>,
+ - or the MIT license
+   <LICENSE-MIT> or
+   <http://opensource.org/licenses/MIT>,
+
+at your option.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.2.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#fc35377b64a66d3c58280ccf36e74085dff15ad5"
+source = "git+https://github.com/sunfishcode/wit-bindgen?branch=keep-supporting-handles-for-now#00b4235bb745e778d02e6a7beb1ef6ac3e337b22"
 dependencies = [
  "anyhow",
  "wit-parser",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-guest-rust"
 version = "0.2.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#fc35377b64a66d3c58280ccf36e74085dff15ad5"
+source = "git+https://github.com/sunfishcode/wit-bindgen?branch=keep-supporting-handles-for-now#00b4235bb745e778d02e6a7beb1ef6ac3e337b22"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust-lib"
 version = "0.2.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#fc35377b64a66d3c58280ccf36e74085dff15ad5"
+source = "git+https://github.com/sunfishcode/wit-bindgen?branch=keep-supporting-handles-for-now#00b4235bb745e778d02e6a7beb1ef6ac3e337b22"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -270,7 +270,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-guest-rust"
 version = "0.2.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#fc35377b64a66d3c58280ccf36e74085dff15ad5"
+source = "git+https://github.com/sunfishcode/wit-bindgen?branch=keep-supporting-handles-for-now#00b4235bb745e778d02e6a7beb1ef6ac3e337b22"
 dependencies = [
  "bitflags",
  "wit-bindgen-guest-rust-macro",
@@ -279,7 +279,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-guest-rust-macro"
 version = "0.2.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#fc35377b64a66d3c58280ccf36e74085dff15ad5"
+source = "git+https://github.com/sunfishcode/wit-bindgen?branch=keep-supporting-handles-for-now#00b4235bb745e778d02e6a7beb1ef6ac3e337b22"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.2.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#fc35377b64a66d3c58280ccf36e74085dff15ad5"
+source = "git+https://github.com/sunfishcode/wit-bindgen?branch=keep-supporting-handles-for-now#00b4235bb745e778d02e6a7beb1ef6ac3e337b22"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,12 @@ edition = "2021"
 members = ['verify']
 
 [dependencies]
-wasi = "0.11.0"
-wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wasi = { version = "0.11.0", default-features = false }
+
+# TODO: Handle support is temporarily removed in upstream wit-bindgen, so use a
+# temporary fork.
+#wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }
+wit-bindgen-guest-rust = { git = "https://github.com/sunfishcode/wit-bindgen", branch = "keep-supporting-handles-for-now" }
 
 [build-dependencies]
 wasm-encoder = "0.18.0"
@@ -17,8 +21,17 @@ object = { version = "0.29.0", default-features = false, features = ['archive'] 
 [lib]
 crate-type = ["cdylib"]
 
+[profile.release]
+# Omit any unwinding support.
+panic = 'abort'
+# Omit integer overflow checks, which include failure messages which require
+# string initializers.
+overflow-checks = false
+
 # Make dev look like a release build since this adapter module won't work with
 # a debug build that uses data segments and such.
 [profile.dev]
 opt-level = 3
 debug = 0
+panic = 'abort'
+overflow-checks = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,9 @@ object = { version = "0.29.0", default-features = false, features = ['archive'] 
 crate-type = ["cdylib"]
 
 [profile.release]
-# Omit any unwinding support.
+# Omit any unwinding support. This is currently the default for wasm, though
+# that could theoretically change in the future.
 panic = 'abort'
-# Omit integer overflow checks, which include failure messages which require
-# string initializers.
-overflow-checks = false
 
 # Make dev look like a release build since this adapter module won't work with
 # a debug build that uses data segments and such.
@@ -34,4 +32,6 @@ overflow-checks = false
 opt-level = 3
 debug = 0
 panic = 'abort'
+# Omit integer overflow checks, which include failure messages which require
+# string initializers.
 overflow-checks = false

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-Apache-2.0_WITH_LLVM-exception
+++ b/LICENSE-Apache-2.0_WITH_LLVM-exception
@@ -1,0 +1,220 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/ORG_CODE_OF_CONDUCT.md
+++ b/ORG_CODE_OF_CONDUCT.md
@@ -1,0 +1,143 @@
+# Bytecode Alliance Organizational Code of Conduct (OCoC)
+
+*Note*: this Code of Conduct pertains to organizations' behavior. Please also see the [Individual Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Preamble
+
+The Bytecode Alliance (BA) welcomes involvement from organizations,
+including commercial organizations.  This document is an
+*organizational* code of conduct, intended particularly to provide
+guidance to commercial organizations.  It is distinct from the
+[Individual Code of Conduct (ICoC)](CODE_OF_CONDUCT.md), and does not 
+replace the ICoC. This OCoC applies to any group of people acting in 
+concert as a BA member or as a participant in BA activities, whether 
+or not that group is formally incorporated in some jurisdiction.
+
+The code of conduct described below is not a set of rigid rules, and
+we did not write it to encompass every conceivable scenario that might
+arise.  For example, it is theoretically possible there would be times
+when asserting patents is in the best interest of the BA community as
+a whole.  In such instances, consult with the BA, strive for
+consensus, and interpret these rules with an intent that is generous
+to the community the BA serves.
+
+While we may revise these guidelines from time to time based on
+real-world experience, overall they are based on a simple principle:
+
+*Bytecode Alliance members should observe the distinction between
+ public community functions and private functions — especially
+ commercial ones — and should ensure that the latter support, or at
+ least do not harm, the former.*
+
+## Guidelines
+
+ * **Do not cause confusion about Wasm standards or interoperability.** 
+ 
+   Having an interoperable WebAssembly core is a high priority for
+   the BA, and members should strive to preserve that core.  It is fine
+   to develop additional non-standard features or APIs, but they
+   should always be clearly distinguished from the core interoperable
+   Wasm.
+ 
+   Treat the WebAssembly name and any BA-associated names with
+   respect, and follow BA trademark and branding guidelines.  If you
+   distribute a customized version of software originally produced by
+   the BA, or if you build a product or service using BA-derived
+   software, use names that clearly distinguish your work from the
+   original.  (You should still provide proper attribution to the
+   original, of course, wherever such attribution would normally be
+   given.)
+     
+   Further, do not use the WebAssembly name or BA-associated names in
+   other public namespaces in ways that could cause confusion, e.g.,
+   in company names, names of commercial service offerings, domain
+   names, publicly-visible social media accounts or online service
+   accounts, etc.  It may sometimes be reasonable, however, to
+   register such a name in a new namespace and then immediately donate
+   control of that account to the BA, because that would help the project
+   maintain its identity.
+
+   For further guidance, see the BA Trademark and Branding Policy
+   [TODO: create policy, then insert link].
+     
+ * **Do not restrict contributors.** If your company requires
+   employees or contractors to sign non-compete agreements, those
+   agreements must not prevent people from participating in the BA or
+   contributing to related projects.
+
+   This does not mean that all non-compete agreements are incompatible
+   with this code of conduct.  For example, a company may restrict an
+   employee's ability to solicit the company's customers.  However, an
+   agreement must not block any form of technical or social
+   participation in BA activities, including but not limited to the
+   implementation of particular features.
+
+   The accumulation of experience and expertise in individual persons,
+   who are ultimately free to direct their energy and attention as
+   they decide, is one of the most important drivers of progress in
+   open source projects.  A company that limits this freedom may hinder
+   the success of the BA's efforts.
+
+ * **Do not use patents as offensive weapons.** If any BA participant
+   prevents the adoption or development of BA technologies by
+   asserting its patents, that undermines the purpose of the
+   coalition.  The collaboration fostered by the BA cannot include
+   members who act to undermine its work.
+ 
+ * **Practice responsible disclosure** for security vulnerabilities.
+   Use designated, non-public reporting channels to disclose technical
+   vulnerabilities, and give the project a reasonable period to
+   respond, remediate, and patch.  [TODO: optionally include the
+   security vulnerability reporting URL here.]
+
+   Vulnerability reporters may patch their company's own offerings, as
+   long as that patching does not significantly delay the reporting of
+   the vulnerability.  Vulnerability information should never be used
+   for unilateral commercial advantage.  Vendors may legitimately
+   compete on the speed and reliability with which they deploy
+   security fixes, but withholding vulnerability information damages
+   everyone in the long run by risking harm to the BA project's
+   reputation and to the security of all users.
+
+ * **Respect the letter and spirit of open source practice.** While
+     there is not space to list here all possible aspects of standard
+     open source practice, some examples will help show what we mean:
+
+   * Abide by all applicable open source license terms.  Do not engage
+     in copyright violation or misattribution of any kind.
+
+   * Do not claim others' ideas or designs as your own.
+
+   * When others engage in publicly visible work (e.g., an upcoming
+     demo that is coordinated in a public issue tracker), do not
+     unilaterally announce early releases or early demonstrations of
+     that work ahead of their schedule in order to secure private
+     advantage (such as marketplace advantage) for yourself.
+
+   The BA reserves the right to determine what constitutes good open
+   source practices and to take action as it deems appropriate to
+   encourage, and if necessary enforce, such practices.
+
+## Enforcement
+
+Instances of organizational behavior in violation of the OCoC may 
+be reported by contacting the Bytecode Alliance CoC team at 
+[report@bytecodealliance.org](mailto:report@bytecodealliance.org). The 
+CoC team will review and investigate all complaints, and will respond 
+in a way that it deems appropriate to the circumstances. The CoC team 
+is obligated to maintain confidentiality with regard to the reporter of 
+an incident. Further details of specific enforcement policies may be 
+posted separately.
+
+When the BA deems an organization in violation of this OCoC, the BA
+will, at its sole discretion, determine what action to take.  The BA
+will decide what type, degree, and duration of corrective action is
+needed, if any, before a violating organization can be considered for
+membership (if it was not already a member) or can have its membership
+reinstated (if it was a member and the BA canceled its membership due
+to the violation).
+
+In practice, the BA's first approach will be to start a conversation,
+with punitive enforcement used only as a last resort.  Violations
+often turn out to be unintentional and swiftly correctable with all
+parties acting in good faith.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+Building secure foundations for software development is at the core of what we do in the Bytecode Alliance. Contributions of external security researchers are a vital part of that.
+
+## Scope
+
+If you believe you've found a security issue in any website, service, or software owned or operated by the Bytecode Alliance, we encourage you to notify us.
+
+## How to Submit a Report
+
+To submit a vulnerability report to the Bytecode Alliance, please contact us at [security@bytecodealliance.org](mailto:security@bytecodealliance.org). Your submission will be reviewed and validated by a member of our security team.
+
+## Safe Harbor
+
+The Bytecode Alliance supports safe harbor for security researchers who:
+
+*   Make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of our services.
+*   Only interact with accounts you own or with explicit permission of the account holder. If you do encounter Personally Identifiable Information (PII) contact us immediately, do not proceed with access, and immediately purge any local information.
+*   Provide us with a reasonable amount of time to resolve vulnerabilities prior to any disclosure to the public or a third-party.
+
+We will consider activities conducted consistent with this policy to constitute "authorized" conduct and will not pursue civil action or initiate a complaint to law enforcement. We will help to the extent we can if legal action is initiated by a third party against you.
+
+Please submit a report to us before engaging in conduct that may be inconsistent with or unaddressed by this policy.
+
+## Preferences
+
+*   Please provide detailed reports with reproducible steps and a clearly defined impact.
+*   Submit one vulnerability per report.
+*   Social engineering (e.g. phishing, vishing, smishing) is prohibited.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,7 +658,7 @@ fn errno_from_wasi_filesystem(err: wasi_filesystem::Errno) -> Errno {
 
 // A black box to prevent the optimizer from generating a lookup table
 // from the match above, which would require a static initializer.
-#[inline(never)]
 fn black_box(x: Errno) -> Errno {
-    unsafe { core::ptr::read_volatile(&x) }
+    core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+    x
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,14 +54,6 @@ unsafe fn register_buffer(buf: *mut u8, buf_len: usize) {
     assert_eq!(old_len, 0);
 }
 
-/// Unregister `buf` and `buf_len`, which should have been used exactly once.
-unsafe fn unregister_buffer(buf: *mut u8, buf_len: usize) {
-    let old_ptr = replace_realloc_global_ptr(null_mut());
-    assert_eq!(old_ptr, buf);
-    let old_len = replace_realloc_global_len(0);
-    assert_eq!(old_len, buf_len);
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn cabi_realloc(
     old_ptr: *mut u8,
@@ -438,8 +430,6 @@ pub unsafe extern "C" fn path_readlink(
 
     let result = fd.readlink_at(path);
 
-    unregister_buffer(buf, buf_len);
-
     let return_value = match &result {
         Ok(path) => {
             assert_eq!(path.as_ptr(), buf);
@@ -473,8 +463,6 @@ unsafe fn path_readlink_slow(
     register_buffer(buffer.as_mut_ptr().cast(), PATH_MAX);
 
     let result = fd.readlink_at(path);
-
-    unregister_buffer(buffer.as_mut_ptr().cast(), PATH_MAX);
 
     let return_value = match &result {
         Ok(path) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,8 @@ use wasi::*;
 /// polyfill.
 const PATH_MAX: usize = 4096;
 
-extern crate alloc;
-
 // We're avoiding static initializers, so replace the standard assert macros
-// with simpler implementation.
+// with simpler implementations.
 macro_rules! assert {
     ($cond:expr $(,)?) => {
         if !$cond {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,19 +41,6 @@ macro_rules! assert_eq {
     };
 }
 
-// We're avoiding static initializers, so don't link in the default allocator.
-struct Alloc {}
-unsafe impl alloc::alloc::GlobalAlloc for Alloc {
-    unsafe fn alloc(&self, _: alloc::alloc::Layout) -> *mut u8 {
-        unreachable()
-    }
-    unsafe fn dealloc(&self, _: *mut u8, _: alloc::alloc::Layout) {
-        unreachable()
-    }
-}
-#[global_allocator]
-static ALLOC: Alloc = Alloc {};
-
 // These functions are defined by the object that the build.rs script produces.
 extern "C" {
     fn replace_realloc_global_ptr(val: *mut u8) -> *mut u8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ wit_bindgen_guest_rust::import!({
 });
 
 use core::arch::wasm32::unreachable;
-use core::mem::forget;
 use core::ptr::null_mut;
 use core::slice;
 use wasi::*;
@@ -461,7 +460,6 @@ pub unsafe extern "C" fn path_readlink(
             assert!(path.len() <= buf_len);
 
             *bufused = path.len();
-            forget(path);
             ERRNO_SUCCESS
         }
         Err(err) => errno_from_wasi_filesystem(err),
@@ -495,7 +493,6 @@ unsafe fn path_readlink_slow(
             let len = core::cmp::min(path.len(), buf_len);
             core::ptr::copy_nonoverlapping(buffer.as_ptr().cast(), buf, len);
             *bufused = len;
-            forget(path);
             ERRNO_SUCCESS
         }
         Err(err) => errno_from_wasi_filesystem(err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,8 +460,9 @@ pub unsafe extern "C" fn path_readlink(
     return_value
 }
 
-// Slow-path for `path_readlink` that allocates a buffer on the stack to
-// ensure that it has a big enough buffer.
+/// Slow-path for `path_readlink` that allocates a buffer on the stack to
+/// ensure that it has a big enough buffer.
+#[inline(never)] // Disable inlining as this has a large stack buffer.
 unsafe fn path_readlink_slow(
     fd: wasi_filesystem::Descriptor,
     path: &[u8],

--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
                     let i = i?;
                     match i.ty {
                         TypeRef::Func(_) => {
-                            if i.module != "wasi" {
+                            if !i.module.starts_with("wasi-") && i.module != "canonical_abi" {
                                 bail!("import from unknown module `{}`", i.module);
                             }
                         }

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -481,6 +481,8 @@ set-times: func(
 ///
 /// Note: This is similar to `pread` in POSIX.
 pread: func(
+    /// The maximum number of bytes to read.
+    len: size,
     /// The offset within the file at which to read.
     offset: filesize,
 ) -> result<list<u8>, errno>
@@ -496,7 +498,7 @@ pwrite: func(
     buf: list<u8>,
     /// The offset within the file at which to write.
     offset: filesize,
-) -> result<_, errno>
+) -> result<size, errno>
 ```
 
 ## `readdir`


### PR DESCRIPTION
Implement a polyfill for `path_readlink` in terms of the preview2 `readlink_at` function.

This involves adding a second wasm global, to hold the buffer size.