### PR TITLE
convert poll interface to use "future" pseudo-handles

### DIFF
--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
 
     let (wasi, _instance) = Wasi::instantiate(&mut store, &component, &linker)?;
 
-    wasi.command(&mut store, 0, 0, Vec::new())?;
+    wasi.command(&mut store, 0, 0, &[])?;
 
     Ok(())
 }

--- a/host/src/poll.rs
+++ b/host/src/poll.rs
@@ -3,10 +3,55 @@
 use crate::{wasi_poll, WasiCtx};
 
 impl wasi_poll::WasiPoll for WasiCtx {
-    fn poll_oneoff(
+    fn drop_future(&mut self, future: wasi_poll::WasiFuture) -> anyhow::Result<()> {
+        todo!()
+    }
+
+    fn bytes_readable(
         &mut self,
-        subs: Vec<wasi_poll::Subscription>,
-    ) -> anyhow::Result<Vec<wasi_poll::Event>> {
+        fd: wasi_poll::Descriptor,
+    ) -> anyhow::Result<wasi_poll::BytesResult> {
+        todo!()
+    }
+
+    fn bytes_writable(
+        &mut self,
+        fd: wasi_poll::Descriptor,
+    ) -> anyhow::Result<wasi_poll::BytesResult> {
+        todo!()
+    }
+
+    fn subscribe_read(
+        &mut self,
+        fd: wasi_poll::Descriptor,
+    ) -> anyhow::Result<wasi_poll::WasiFuture> {
+        todo!()
+    }
+
+    fn subscribe_write(
+        &mut self,
+        fd: wasi_poll::Descriptor,
+    ) -> anyhow::Result<wasi_poll::WasiFuture> {
+        todo!()
+    }
+
+    fn subscribe_wall_clock(
+        &mut self,
+        when: wasi_poll::Datetime,
+        absolute: bool,
+    ) -> anyhow::Result<wasi_poll::WasiFuture> {
+        todo!()
+    }
+
+    fn subscribe_monotonic_clock(
+        &mut self,
+        when: wasi_poll::Instant,
+        absolute: bool,
+    ) -> anyhow::Result<wasi_poll::WasiFuture> {
+        todo!()
+    }
+
+    fn poll_oneoff(&mut self, futures: Vec<wasi_poll::WasiFuture>) -> anyhow::Result<Vec<bool>> {
         todo!()
     }
 }


### PR DESCRIPTION
Per discussion with pchickey, this modifies the poll API to use "futures" rather than a `subscription` type.  The former is arguably closer to the API we'll use once resource support is finalized.

You can create a future by calling `subscribe-read`, `subscribe-write`, `subscribe-wall-clock`, or `subscribe-monotonic-clock` and then poll any number of futures using `poll-oneoff`.  The result is a list of booleans indicating which futures have completed.

In order to determine how many bytes are readable or writable, the application may call `bytes-readable` or `bytes-writable`, respectively, passing the descriptor of interest.

Finally, a future pseudo-handle may be disposed of using `drop-future`, analogous to disposing of a resource handle.

Note that the updated API does not include `userdata` type, fields, or parameters, so the Preview 1 adapter will need to track them itself using a table of some kind.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>