### PR TITLE
Change the `len` parameter of `fadvise` to `filesize`.

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -8,7 +8,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         &mut self,
         fd: wasi_filesystem::Descriptor,
         offset: wasi_filesystem::Filesize,
-        len: wasi_filesystem::Size,
+        len: wasi_filesystem::Filesize,
         advice: wasi_filesystem::Advice,
     ) -> HostResult<(), wasi_filesystem::Errno> {
         todo!()

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -413,7 +413,7 @@ fadvise: func(
     /// The offset within the file to which the advisory applies.
     offset: filesize,
     /// The length of the region to which the advisory applies.
-    len: size,
+    len: filesize,
     /// The advice.
     advice: advice
 ) -> result<_, errno>


### PR DESCRIPTION
Fadvise can apply to regions of files larger than the linear memory address space, so it wants a `filesize` (which is u64) rather than a `size` (which is u32 on wasm32).